### PR TITLE
Add option for logging of non-fatal exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
     {
       "name": "Bob van de Vijver",
       "email": "bob@kick-in.nl"
+    },
+    {
+      "name": "Sven Mol",
+      "email": "sven@kick-in.nl"
     }
   ],
   "require": {


### PR DESCRIPTION
Adds a function `handleException` to the `ExceptionHandler` allowing for logging of a non-fatal error. Note that it doesn't support logging of multiple exceptions.