### PR TITLE
[BC] Remove Container from Configuration class

### DIFF
--- a/Configuration/ConfigurationInterface.php
+++ b/Configuration/ConfigurationInterface.php
@@ -8,13 +8,6 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 interface ConfigurationInterface
 {
   /**
-   * ConfigurationInterface constructor.
-   *
-   * @param ContainerInterface $container
-   */
-  public function __construct(ContainerInterface $container);
-
-  /**
    * Indicate whether the current environment is a production environment
    *
    * @return bool

--- a/Configuration/EmptyConfiguration.php
+++ b/Configuration/EmptyConfiguration.php
@@ -8,6 +8,21 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 class EmptyConfiguration implements ConfigurationInterface
 {
   /**
+   * @var string
+   */
+  private $cacheDir;
+
+  /**
+   * EmptyConfiguration constructor.
+   *
+   * @param string $cacheDir
+   */
+  public function __construct($cacheDir)
+  {
+    $this->cacheDir = $cacheDir;
+  }
+
+  /**
    * @inheritdoc
    */
   public function isProductionEnvironment()
@@ -20,7 +35,7 @@ class EmptyConfiguration implements ConfigurationInterface
    */
   public function getBacktraceFolder()
   {
-    return '/tmp/exception-handler';
+    return $this->cacheDir . '/exception-handler';
   }
 
   /**

--- a/Configuration/EmptyConfiguration.php
+++ b/Configuration/EmptyConfiguration.php
@@ -7,22 +7,6 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class EmptyConfiguration implements ConfigurationInterface
 {
-
-  /**
-   * @var ContainerInterface
-   */
-  private $container;
-
-  /**
-   * EmptyConfiguration constructor.
-   *
-   * @param ContainerInterface $container
-   */
-  public function __construct(ContainerInterface $container)
-  {
-    $this->container = $container;
-  }
-
   /**
    * @inheritdoc
    */
@@ -36,7 +20,7 @@ class EmptyConfiguration implements ConfigurationInterface
    */
   public function getBacktraceFolder()
   {
-    return $this->container->getParameter('kernel.cache_dir') . '/exceptionhandler';
+    return '/tmp/exception-handler';
   }
 
   /**

--- a/Handler/ExceptionHandler.php
+++ b/Handler/ExceptionHandler.php
@@ -6,7 +6,6 @@ use DateTime;
 use Exception;
 use Kickin\ExceptionHandlerBundle\Backtrace\BacktraceLogFile;
 use Kickin\ExceptionHandlerBundle\Configuration\ConfigurationInterface;
-use Kickin\ExceptionHandlerBundle\Configuration\EmptyConfiguration;
 use Kickin\ExceptionHandlerBundle\Exceptions\FileAlreadyExistsException;
 use Kickin\ExceptionHandlerBundle\Exceptions\UploadFailedException;
 use Swift_Attachment;
@@ -89,10 +88,6 @@ class ExceptionHandler implements EventSubscriberInterface
   public function __construct(Swift_Mailer $mailer, Swift_Transport $transport, TokenStorageInterface $tokenStorage,
                               Twig_Environment $twig, ConfigurationInterface $configuration)
   {
-    if ($configuration instanceof EmptyConfiguration) {
-      throw new \InvalidArgumentException("You need to create your own configuration class and register it correctly in order to use this bundle!");
-    }
-
     $this->mailer          = $mailer;
     $this->mailerTransport = $transport;
     $this->tokenStorage    = $tokenStorage;

--- a/README.md
+++ b/README.md
@@ -37,24 +37,17 @@ swiftmailer:
         spool: { type: memory }
 ```
 
-4. Implement your custom configuration class. This should implement the `Configuration\ConfigurationInterface`. For
-an implementation example, have a look at `Configuration\EmptyConfiguration`. Note that the custom file is required:
-it is checked whether the `EmptyConfiguration` is still loaded, which will make this bundle throw an exception if that
-is the case.
+4. Implement your custom configuration service. This should implement the `Configuration\ConfigurationInterface`. It will
+ then be autowired to the `ExceptionHandler`. For an implementation example, have a look at `Configuration\EmptyConfiguration`.
 
-5. Register your configuration class in the kernel parameters (either `parameters.yml` or `config.yml`):
-```yml
-parameters:
-    kickin.exceptionhandler.configuration.class: <your_class_here>
-```
-
-6. (Optional) By default, the default configuration doesn't include access to other services in the `Configuration` class.
-Should you require these, include the new class in your own `services.yml` to decorate the default service. If you use autowiring, you're done.
-Otherwise, configure the arguments of your class here as well.
+6. (Optional) If you don't use autowiring, or need manual configuration for your configuration service, configure your
+configuration service in the regular way. Include the new class in your own `services.yml`, and configure the service as you like:
 ```yml
 services:
     <your_class_here>:
-        decorates: kickin.exceptionhandler.configuration
+        arguments:
+          $cacheDir: '%kernel.cache_dir%'
+          <argument>: '@someservice'
 ```
 
 That should be it, happy exception mailing!

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In order for this bundle to work, you are required to follow the following steps
 php composer.phar require kick-in/exception-handler-bundle
 ```
 
-1. Enable the bundle in your `AppKernel.php`
+2. Enable the bundle in your `AppKernel.php`
 ```
 $bundles = [
 ....
@@ -18,7 +18,7 @@ $bundles = [
 ];
 ```
 
-2. Create the `exception_mailer` swiftmailer instance. For example:
+3. Create the `exception_mailer` swiftmailer instance. For example:
 ```yml
 swiftmailer:
     default_mailer: default
@@ -37,15 +37,24 @@ swiftmailer:
         spool: { type: memory }
 ```
 
-3. Implement your custom configuration class. This should implement the `Configuration\ConfigurationInterface`. For 
+4. Implement your custom configuration class. This should implement the `Configuration\ConfigurationInterface`. For
 an implementation example, have a look at `Configuration\EmptyConfiguration`. Note that the custom file is required:
 it is checked whether the `EmptyConfiguration` is still loaded, which will make this bundle throw an exception if that
 is the case.
 
-4. Register your configuration class in the kernel parameters (either `parameters.yml` or `config.yml`):
+5. Register your configuration class in the kernel parameters (either `parameters.yml` or `config.yml`):
 ```yml
 parameters:
     kickin.exceptionhandler.configuration.class: <your_class_here>
+```
+
+6. (Optional) By default, the default configuration doesn't include access to other services in the `Configuration` class.
+Should you require these, include the new class in your own `services.yml` to decorate the default service. If you use autowiring, you're done.
+Otherwise, configure the arguments of your class here as well.
+```yml
+services:
+    <your_class_here>:
+        decorates: kickin.exceptionhandler.configuration
 ```
 
 That should be it, happy exception mailing!

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ swiftmailer:
 ```
 
 4. Implement your custom configuration service. This should implement the `Configuration\ConfigurationInterface`. It will
- then be autowired to the `ExceptionHandler`. [Implementation example](Resources/doc/configuration-example.md).
+ then be autowired to the `ExceptionHandler`. You can check an example implementation [here](Resources/doc/configuration-example.md).
 
 6. (Optional) If you don't use autowiring, or need manual configuration for your configuration service, configure your
 configuration service in the regular way. Include the new class in your own `services.yml`, and configure the service as you like:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ swiftmailer:
 ```
 
 4. Implement your custom configuration service. This should implement the `Configuration\ConfigurationInterface`. It will
- then be autowired to the `ExceptionHandler`. For an implementation example, have a look at `Configuration\EmptyConfiguration`.
+ then be autowired to the `ExceptionHandler`. [Implementation example](Resources/doc/configuration-example.md).
 
 6. (Optional) If you don't use autowiring, or need manual configuration for your configuration service, configure your
 configuration service in the regular way. Include the new class in your own `services.yml`, and configure the service as you like:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,9 +5,6 @@ services:
   kickin.exceptionhandler.configuration:
     class: "%kickin.exceptionhandler.configuration.class%"
     public: false
-    lazy: false  # This cannot be true as that will throw fatal errors!
-    arguments:
-      - "@service_container"
 
   kickin.exceptionhandler.handler:
     class: Kickin\ExceptionHandlerBundle\Handler\ExceptionHandler

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,20 +1,7 @@
-parameters:
-  kickin.exceptionhandler.configuration.class: Kickin\ExceptionHandlerBundle\Configuration\EmptyConfiguration
-
 services:
-  kickin.exceptionhandler.configuration:
-    class: "%kickin.exceptionhandler.configuration.class%"
-    public: false
-
   kickin.exceptionhandler.handler:
     class: Kickin\ExceptionHandlerBundle\Handler\ExceptionHandler
     lazy: true
     public: false
-    arguments:
-      - "@swiftmailer.mailer.exception_mailer"
-      - "@swiftmailer.mailer.exception_mailer.transport.real"
-      - "@security.token_storage"
-      - "@twig"
-      - "@kickin.exceptionhandler.configuration"
-    tags:
-      - { name: kernel.event_subscriber }
+    autowire: true
+    autoconfigure: true

--- a/Resources/doc/configuration-example.md
+++ b/Resources/doc/configuration-example.md
@@ -1,11 +1,11 @@
+```php
 <?php
 
 namespace Kickin\ExceptionHandlerBundle\Configuration;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
-class EmptyConfiguration implements ConfigurationInterface
+class ExampleConfiguration implements ConfigurationInterface
 {
   /**
    * @var string
@@ -84,3 +84,5 @@ class EmptyConfiguration implements ConfigurationInterface
     return 'git-hash';
   }
 }
+
+```


### PR DESCRIPTION
Symfony no longer wants you to inject the container as it pleases you. Therefore I propose to remove it from the Configuration class. This breaks backwards compatibility.