### PR TITLE
Update documentation related to strict autowiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ swiftmailer:
 ```
 
 4. Implement your custom configuration service. This should implement the `Configuration\ConfigurationInterface`. It will
- then be autowired to the `ExceptionHandler`. You can check an example implementation [here](Resources/doc/configuration-example.md).
+ then be autowired to the `ExceptionHandler` if you have set `container.autowiring.strict_mode` to false. Otherwise (default in Symfony >=4.0), alias the `Kickin\ExceptionHandlerBundle\Configuration\ConfigurationInterface` service to your custom configuration service. You can check an example implementation [here](Resources/doc/configuration-example.md).
 
 6. (Optional) If you don't use autowiring, or need manual configuration for your configuration service, configure your
 configuration service in the regular way. Include the new class in your own `services.yml`, and configure the service as you like:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,9 +2,9 @@
 
 # 2.0
 
-The 2.0 release marks the usage of autowiring for the configuration class. You don't need to change anything if you use autowiring, but you can remove the `kickin.exceptionhandler.configuration.class` parameter from you configuration.
+The 2.0 release marks the usage of autowiring for the configuration class. If you set the `container.autowiring.strict_mode` parameter to true (default for Symfony >=4.0), you need to alias the `Kickin\ExceptionHandlerBundle\Configuration\ConfigurationInterface` class to your configuration class. You can remove the `kickin.exceptionhandler.configuration.class` parameter from your configuration.
 
-If you don't use autowiring, check the installion guide on what you need to register for the bundle to work.
+If you don't use autowiring, check the installation guide on what you need to register for the bundle to work.
 
 # 1.1
 


### PR DESCRIPTION
The documentation was not correct when strict autowiring is used (default in Symfony <=4.0), which could lead to problems updating or implementing the bundle.